### PR TITLE
Lazy factory that builds client only when needed

### DIFF
--- a/src/Secret/Proxy/String/Factory/LazyWithClientAsClassMemberFactory.php
+++ b/src/Secret/Proxy/String/Factory/LazyWithClientAsClassMemberFactory.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace de\codenamephp\platform\secretsManager\base\Secret\Proxy\String\Factory;
+
+use Closure;
+use de\codenamephp\platform\secretsManager\base\Client\ClientInterface;
+use de\codenamephp\platform\secretsManager\base\Secret\Proxy\String\StringProxyInterface;
+use de\codenamephp\platform\secretsManager\base\Secret\SecretInterface;
+
+/**
+ * Wrapper for the WithClientAsClassMemberFactory that uses a callback to create the client lazy instead of passing it in the constructor. This makes it
+ * possible to only create the client when it is actually needed which is useful when some users never need to use anything that needs the client. So they
+ * don't even need to install the client library with auth etc.
+ */
+final class LazyWithClientAsClassMemberFactory implements StringProxyFactoryInterface {
+
+  public WithClientAsClassMemberFactory $proxyFactory;
+
+  /**
+   * @param Closure():ClientInterface $clientFactory A closure that returns the client when called. This is used to create the client lazy instead of passing it
+   */
+  public function __construct(
+    public readonly Closure $clientFactory,
+  ) {}
+
+  /**
+   * @psalm-suppress RedundantPropertyInitializationCheck that's what makes it lazy!
+   */
+  public function getProxyFactory() : WithClientAsClassMemberFactory {
+    return $this->proxyFactory ??= new WithClientAsClassMemberFactory(($this->clientFactory)());
+  }
+
+  public function build(SecretInterface $secret) : StringProxyInterface {
+    return $this->getProxyFactory()->build($secret);
+  }
+
+  public function buildMultiple(SecretInterface ...$secrets) : array {
+    return $this->getProxyFactory()->buildMultiple(...$secrets);
+  }
+}

--- a/test/Secret/Proxy/String/Factory/LazyWithClientAsClassMemberFactoryTest.php
+++ b/test/Secret/Proxy/String/Factory/LazyWithClientAsClassMemberFactoryTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace de\codenamephp\platform\secretsManager\base\test\Secret\Proxy\String\Factory;
+
+use de\codenamephp\platform\secretsManager\base\Client\ClientInterface;
+use de\codenamephp\platform\secretsManager\base\Secret\Proxy\String\Factory\LazyWithClientAsClassMemberFactory;
+use de\codenamephp\platform\secretsManager\base\Secret\Proxy\String\WithClientAsClassMember;
+use de\codenamephp\platform\secretsManager\base\Secret\SecretInterface;
+use PHPUnit\Framework\TestCase;
+
+final class LazyWithClientAsClassMemberFactoryTest extends TestCase {
+
+  public function testBuild() : void {
+    $client = $this->createMock(ClientInterface::class);
+    $secret = $this->createMock(SecretInterface::class);
+
+    $sut = new LazyWithClientAsClassMemberFactory(static fn() => $client);
+
+    $proxy = $sut->build($secret);
+
+    self::assertInstanceOf(WithClientAsClassMember::class, $proxy);
+    self::assertSame($client, $proxy->client);
+    self::assertSame($secret, $proxy->secret);
+  }
+
+  public function test__construct() : void {
+    $closure = static fn() => null;
+
+    $sut = new LazyWithClientAsClassMemberFactory($closure);
+
+    self::assertSame($closure, $sut->clientFactory);
+  }
+
+  public function testGetProxyFactory() : void {
+    $client = $this->createMock(ClientInterface::class);
+
+    $sut = new LazyWithClientAsClassMemberFactory(static fn() => $client);
+    $proxyFactory = $sut->getProxyFactory();
+
+    self::assertSame($client, $proxyFactory->client);
+    self::assertSame($proxyFactory, $sut->getProxyFactory());
+  }
+
+  public function testBuildMultiple() : void {
+    $client = $this->createMock(ClientInterface::class);
+    $secret1 = $this->createMock(SecretInterface::class);
+    $secret2 = $this->createMock(SecretInterface::class);
+    $secret3 = $this->createMock(SecretInterface::class);
+
+    $sut = new LazyWithClientAsClassMemberFactory(static fn() => $client);
+
+    $proxies = $sut->buildMultiple($secret1, $secret2, $secret3);
+
+    self::assertContainsOnlyInstancesOf(WithClientAsClassMember::class, $proxies);
+    self::assertCount(3, $proxies);
+    self::assertSame($client, $proxies[0]->client);
+    self::assertSame($secret1, $proxies[0]->secret);
+    self::assertSame($client, $proxies[1]->client);
+    self::assertSame($secret2, $proxies[1]->secret);
+    self::assertSame($client, $proxies[2]->client);
+    self::assertSame($secret3, $proxies[2]->secret);
+  }
+}


### PR DESCRIPTION
This PR adds a lazy factory that builds the client only when it is needed. This way users that don't actually access the client won't need to authenticate